### PR TITLE
Set file mode to 0444 instead of 0666

### DIFF
--- a/txtarfs.go
+++ b/txtarfs.go
@@ -20,7 +20,10 @@ func As(ar *txtar.Archive) fs.FS {
 			Sys: f,
 		}
 	}
-	m.ChmodAll(0666)
+	// Create entries for directories
+	// Mark files as read-only
+	// Mark directories as read-only but traversable
+	m.ChmodAll(0444)
 	return m
 }
 

--- a/txtarfs_test.go
+++ b/txtarfs_test.go
@@ -49,7 +49,7 @@ func TestBasics(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if mode := fi.Mode().Perm(); mode&0666 != 0666 {
+			if mode := fi.Mode().Perm(); mode&0444 != 0444 {
 				return fmt.Errorf("%s has mode %v", path, mode)
 			}
 			return nil


### PR DESCRIPTION
Set file mode to `0444`(`r--r--r--`)  as [txtar](https://pkg.go.dev/golang.org/x/tools/txtar) is a read-only fileformat, and in general the [`io/fs.FS`](https://pkg.go.dev/io/fs#FS) API doesn't allow to modify files.