### PR TITLE
From: skip ErrPermission if FileMode says file is not readable

### DIFF
--- a/txtarfs.go
+++ b/txtarfs.go
@@ -2,6 +2,7 @@
 package txtarfs
 
 import (
+	"errors"
 	"io/fs"
 
 	"github.com/josharian/mapfs"
@@ -51,6 +52,13 @@ func From(fsys fs.FS) (*txtar.Archive, error) {
 		}
 		data, err := fs.ReadFile(fsys, path)
 		if err != nil {
+			if errors.Is(err, fs.ErrPermission) {
+				// Skip if marked as not readable in FileMode in either user/group/others
+				// (the io/fs.FS API doesn't tell which one is enforced)
+				if info, err2 := d.Info(); err2 == nil && info.Mode()&0444 != 0444 {
+					return nil
+				}
+			}
 			return err
 		}
 		ar.Files = append(ar.Files, txtar.File{Name: path, Data: data})


### PR DESCRIPTION
In `From`, skip files for which [`io/fs.ErrPermission`](https://pkg.go.dev/io/fs#ErrPermission) is returned by [`ReadFile`](https://pkg.go.dev/io/fs#ReadFile) if the file has a [`FileMode`](https://pkg.go.dev/io/fs#FileMode) which indicates that the file is not readable by either user/group/others (this is just a best effort as, unfortunately, the io/fs.FS API doesn't tell which bit might be enforced).

This allows more fs.FS to be convertible to txtar as this eliminates one case of fatal error.

Note: the documentation for [`From`](https://pkg.go.dev/github.com/josharian/txtarfs#From) already contains a warning about converting to txtar being lossy, so I don't think this is a breaking change. 